### PR TITLE
fix(settings): Have the workers default to one less than machine count

### DIFF
--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -7,7 +7,7 @@ def test_settings_init():
     settings = RecipeSettings()
 
     assert settings.folder is None
-    assert settings.workers == 2
+    assert settings.workers >= 1
     assert not settings.reload_old
     assert not settings.report_out
 


### PR DESCRIPTION
We've come to realize that, most of the time, people just want to set the number of workers to one less than the CPU count.  This fix implements this type of auto-sensing so people don't constantly have to override the default.