### PR TITLE
fix(direct): Add support for direct illuminance results next to total

### DIFF
--- a/lbt_recipes/annual_daylight/flow/main.py
+++ b/lbt_recipes/annual_daylight/flow/main.py
@@ -16,7 +16,8 @@ import luigi
 import os
 import pathlib
 from queenbee_local import QueenbeeTask
-from .dependencies.annual_daylight_ray_tracing import _AnnualDaylightRayTracing_877ed6d8Orchestrator as AnnualDaylightRayTracing_877ed6d8Workerbee
+from queenbee_local import load_input_param as qb_load_input_param
+from .dependencies.annual_daylight_ray_tracing import _AnnualDaylightRayTracing_f5da0c9fOrchestrator as AnnualDaylightRayTracing_f5da0c9fWorkerbee
 
 
 _default_inputs = {   'cpu_count': 50,
@@ -155,7 +156,7 @@ class AnnualDaylightRaytracingLoop(luigi.Task):
         return inputs
 
     def run(self):
-        yield [AnnualDaylightRayTracing_877ed6d8Workerbee(_input_params=self.map_dag_inputs)]
+        yield [AnnualDaylightRayTracing_f5da0c9fWorkerbee(_input_params=self.map_dag_inputs)]
         done_file = pathlib.Path(self.execution_folder, 'annual_daylight_raytracing.done')
         done_file.parent.mkdir(parents=True, exist_ok=True)
         done_file.write_text('done!')
@@ -183,7 +184,7 @@ class AnnualDaylightRaytracing(luigi.Task):
     def items(self):
         try:
             # assume the input is a file
-            return QueenbeeTask.load_input_param(self.sensor_grids)
+            return qb_load_input_param(self.sensor_grids)
         except:
             # it is a parameter
             return pathlib.Path(self.input()['SplitGridFolder']['sensor_grids'].path).as_posix()
@@ -228,7 +229,7 @@ class CalculateAnnualMetrics(QueenbeeTask):
 
     @property
     def folder(self):
-        value = pathlib.Path('results')
+        value = pathlib.Path('results/total')
         return value.as_posix() if value.is_absolute() \
             else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
 
@@ -280,6 +281,168 @@ class CalculateAnnualMetrics(QueenbeeTask):
             {
                 'name': 'annual-metrics', 'from': 'metrics',
                 'to': pathlib.Path(self.execution_folder, 'metrics').resolve().as_posix(),
+                'optional': False,
+                'type': 'folder'
+            }]
+
+
+class CopyGridInfo(QueenbeeTask):
+    """Copy a file or folder to a destination."""
+
+    # DAG Input parameters
+    _input_params = luigi.DictParameter()
+
+    # Task inputs
+    @property
+    def src(self):
+        value = pathlib.Path(self.input()['CreateRadFolder']['sensor_grids_file'].path)
+        return value.as_posix() if value.is_absolute() \
+            else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
+
+    @property
+    def execution_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def initiation_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def params_folder(self):
+        return pathlib.Path(self.execution_folder, self._input_params['params_folder']).resolve().as_posix()
+
+    def command(self):
+        return 'echo copying input path...'
+
+    def requires(self):
+        return {'CreateRadFolder': CreateRadFolder(_input_params=self._input_params)}
+
+    def output(self):
+        return {
+            'dst': luigi.LocalTarget(
+                pathlib.Path(self.execution_folder, 'results/direct/grids_info.json').resolve().as_posix()
+            )
+        }
+
+    @property
+    def input_artifacts(self):
+        return [
+            {'name': 'src', 'to': 'input_path', 'from': self.src, 'optional': False}]
+
+    @property
+    def output_artifacts(self):
+        return [
+            {
+                'name': 'dst', 'from': 'input_path',
+                'to': pathlib.Path(self.execution_folder, 'results/direct/grids_info.json').resolve().as_posix(),
+                'optional': False,
+                'type': 'folder'
+            }]
+
+
+class CopyRedistInfo(QueenbeeTask):
+    """Copy a file or folder to a destination."""
+
+    # DAG Input parameters
+    _input_params = luigi.DictParameter()
+
+    # Task inputs
+    @property
+    def src(self):
+        value = pathlib.Path(self.input()['SplitGridFolder']['dist_info'].path)
+        return value.as_posix() if value.is_absolute() \
+            else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
+
+    @property
+    def execution_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def initiation_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def params_folder(self):
+        return pathlib.Path(self.execution_folder, self._input_params['params_folder']).resolve().as_posix()
+
+    def command(self):
+        return 'echo copying input path...'
+
+    def requires(self):
+        return {'SplitGridFolder': SplitGridFolder(_input_params=self._input_params)}
+
+    def output(self):
+        return {
+            'dst': luigi.LocalTarget(
+                pathlib.Path(self.execution_folder, 'initial_results/final/direct/_redist_info.json').resolve().as_posix()
+            )
+        }
+
+    @property
+    def input_artifacts(self):
+        return [
+            {'name': 'src', 'to': 'input_path', 'from': self.src, 'optional': False}]
+
+    @property
+    def output_artifacts(self):
+        return [
+            {
+                'name': 'dst', 'from': 'input_path',
+                'to': pathlib.Path(self.execution_folder, 'initial_results/final/direct/_redist_info.json').resolve().as_posix(),
+                'optional': False,
+                'type': 'folder'
+            }]
+
+
+class CopySunUpHours(QueenbeeTask):
+    """Copy a file or folder to a destination."""
+
+    # DAG Input parameters
+    _input_params = luigi.DictParameter()
+
+    # Task inputs
+    @property
+    def src(self):
+        value = pathlib.Path(self.input()['ParseSunUpHours']['sun_up_hours'].path)
+        return value.as_posix() if value.is_absolute() \
+            else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
+
+    @property
+    def execution_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def initiation_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def params_folder(self):
+        return pathlib.Path(self.execution_folder, self._input_params['params_folder']).resolve().as_posix()
+
+    def command(self):
+        return 'echo copying input path...'
+
+    def requires(self):
+        return {'ParseSunUpHours': ParseSunUpHours(_input_params=self._input_params)}
+
+    def output(self):
+        return {
+            'dst': luigi.LocalTarget(
+                pathlib.Path(self.execution_folder, 'results/direct/sun-up-hours.txt').resolve().as_posix()
+            )
+        }
+
+    @property
+    def input_artifacts(self):
+        return [
+            {'name': 'src', 'to': 'input_path', 'from': self.src, 'optional': False}]
+
+    @property
+    def output_artifacts(self):
+        return [
+            {
+                'name': 'dst', 'from': 'input_path',
+                'to': pathlib.Path(self.execution_folder, 'results/direct/sun-up-hours.txt').resolve().as_posix(),
                 'optional': False,
                 'type': 'folder'
             }]
@@ -523,7 +686,7 @@ class CreateRadFolder(QueenbeeTask):
             ),
             
             'sensor_grids_file': luigi.LocalTarget(
-                pathlib.Path(self.execution_folder, 'results/grids_info.json').resolve().as_posix()
+                pathlib.Path(self.execution_folder, 'results/total/grids_info.json').resolve().as_posix()
             ),
             'sensor_grids': luigi.LocalTarget(
                 pathlib.Path(
@@ -556,7 +719,7 @@ class CreateRadFolder(QueenbeeTask):
                 
             {
                 'name': 'sensor-grids-file', 'from': 'model/grid/_info.json',
-                'to': pathlib.Path(self.execution_folder, 'results/grids_info.json').resolve().as_posix(),
+                'to': pathlib.Path(self.execution_folder, 'results/total/grids_info.json').resolve().as_posix(),
                 'optional': False,
                 'type': 'file'
             }]
@@ -779,7 +942,7 @@ class ParseSunUpHours(QueenbeeTask):
     def output(self):
         return {
             'sun_up_hours': luigi.LocalTarget(
-                pathlib.Path(self.execution_folder, 'results/sun-up-hours.txt').resolve().as_posix()
+                pathlib.Path(self.execution_folder, 'results/total/sun-up-hours.txt').resolve().as_posix()
             )
         }
 
@@ -793,13 +956,13 @@ class ParseSunUpHours(QueenbeeTask):
         return [
             {
                 'name': 'sun-up-hours', 'from': 'sun-up-hours.txt',
-                'to': pathlib.Path(self.execution_folder, 'results/sun-up-hours.txt').resolve().as_posix(),
+                'to': pathlib.Path(self.execution_folder, 'results/total/sun-up-hours.txt').resolve().as_posix(),
                 'optional': False,
                 'type': 'file'
             }]
 
 
-class RestructureResults(QueenbeeTask):
+class RestructureDirectResults(QueenbeeTask):
     """Restructure files in a distributed folder."""
 
     # DAG Input parameters
@@ -812,7 +975,7 @@ class RestructureResults(QueenbeeTask):
 
     @property
     def input_folder(self):
-        value = pathlib.Path('initial_results/final')
+        value = pathlib.Path('initial_results/final/direct')
         return value.as_posix() if value.is_absolute() \
             else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
 
@@ -837,7 +1000,7 @@ class RestructureResults(QueenbeeTask):
     def output(self):
         return {
             'output_folder': luigi.LocalTarget(
-                pathlib.Path(self.execution_folder, 'results').resolve().as_posix()
+                pathlib.Path(self.execution_folder, 'results/direct').resolve().as_posix()
             )
         }
 
@@ -851,7 +1014,65 @@ class RestructureResults(QueenbeeTask):
         return [
             {
                 'name': 'output-folder', 'from': 'output_folder',
-                'to': pathlib.Path(self.execution_folder, 'results').resolve().as_posix(),
+                'to': pathlib.Path(self.execution_folder, 'results/direct').resolve().as_posix(),
+                'optional': False,
+                'type': 'folder'
+            }]
+
+
+class RestructureResults(QueenbeeTask):
+    """Restructure files in a distributed folder."""
+
+    # DAG Input parameters
+    _input_params = luigi.DictParameter()
+
+    # Task inputs
+    @property
+    def extension(self):
+        return 'ill'
+
+    @property
+    def input_folder(self):
+        value = pathlib.Path('initial_results/final/total')
+        return value.as_posix() if value.is_absolute() \
+            else pathlib.Path(self.initiation_folder, value).resolve().as_posix()
+
+    @property
+    def execution_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def initiation_folder(self):
+        return pathlib.Path(self._input_params['simulation_folder']).as_posix()
+
+    @property
+    def params_folder(self):
+        return pathlib.Path(self.execution_folder, self._input_params['params_folder']).resolve().as_posix()
+
+    def command(self):
+        return 'honeybee-radiance grid merge-folder ./input_folder ./output_folder  {extension}'.format(extension=self.extension)
+
+    def requires(self):
+        return {'AnnualDaylightRaytracing': AnnualDaylightRaytracing(_input_params=self._input_params)}
+
+    def output(self):
+        return {
+            'output_folder': luigi.LocalTarget(
+                pathlib.Path(self.execution_folder, 'results/total').resolve().as_posix()
+            )
+        }
+
+    @property
+    def input_artifacts(self):
+        return [
+            {'name': 'input_folder', 'to': 'input_folder', 'from': self.input_folder, 'optional': False}]
+
+    @property
+    def output_artifacts(self):
+        return [
+            {
+                'name': 'output-folder', 'from': 'output_folder',
+                'to': pathlib.Path(self.execution_folder, 'results/total').resolve().as_posix(),
                 'optional': False,
                 'type': 'folder'
             }]
@@ -913,7 +1134,7 @@ class SplitGridFolder(QueenbeeTask):
             ),
             
             'dist_info': luigi.LocalTarget(
-                pathlib.Path(self.execution_folder, 'initial_results/final/_redist_info.json').resolve().as_posix()
+                pathlib.Path(self.execution_folder, 'initial_results/final/total/_redist_info.json').resolve().as_posix()
             ),
             'sensor_grids': luigi.LocalTarget(
                 pathlib.Path(
@@ -939,7 +1160,7 @@ class SplitGridFolder(QueenbeeTask):
                 
             {
                 'name': 'dist-info', 'from': 'output_folder/_redist_info.json',
-                'to': pathlib.Path(self.execution_folder, 'initial_results/final/_redist_info.json').resolve().as_posix(),
+                'to': pathlib.Path(self.execution_folder, 'initial_results/final/total/_redist_info.json').resolve().as_posix(),
                 'optional': False,
                 'type': 'file'
             }]
@@ -949,7 +1170,7 @@ class SplitGridFolder(QueenbeeTask):
         return [{'name': 'sensor-grids', 'from': 'output_folder/_info.json', 'to': pathlib.Path(self.params_folder, 'output_folder/_info.json').resolve().as_posix()}]
 
 
-class _Main_877ed6d8Orchestrator(luigi.WrapperTask):
+class _Main_f5da0c9fOrchestrator(luigi.WrapperTask):
     """Runs all the tasks in this module."""
     # user input for this module
     _input_params = luigi.DictParameter()
@@ -961,4 +1182,4 @@ class _Main_877ed6d8Orchestrator(luigi.WrapperTask):
         return params
 
     def requires(self):
-        yield [CalculateAnnualMetrics(_input_params=self.input_values)]
+        yield [CalculateAnnualMetrics(_input_params=self.input_values), CopyGridInfo(_input_params=self.input_values), CopyRedistInfo(_input_params=self.input_values), CopySunUpHours(_input_params=self.input_values), RestructureDirectResults(_input_params=self.input_values)]

--- a/lbt_recipes/annual_daylight/package.json
+++ b/lbt_recipes/annual_daylight/package.json
@@ -6,7 +6,7 @@
     "type": "MetaData",
     "annotations": {},
     "name": "annual-daylight",
-    "tag": "0.6.9",
+    "tag": "0.8.9",
     "app_version": null,
     "keywords": [
       "honeybee",
@@ -491,7 +491,7 @@
       "from": {
         "type": "FolderReference",
         "annotations": {},
-        "path": "results"
+        "path": "results/total"
       },
       "alias": [
         {

--- a/lbt_recipes/annual_daylight/run.py
+++ b/lbt_recipes/annual_daylight/run.py
@@ -39,7 +39,7 @@ class LetAnnualDaylightFly(luigi.WrapperTask):
     _input_params = luigi.DictParameter()
 
     def requires(self):
-        yield [annual_daylight_workerbee._Main_877ed6d8Orchestrator(_input_params=self._input_params)]
+        yield [annual_daylight_workerbee._Main_f5da0c9fOrchestrator(_input_params=self._input_params)]
 
 
 def start(project_folder, user_values, workers):

--- a/tests/recipes_test.py
+++ b/tests/recipes_test.py
@@ -31,7 +31,8 @@ def run_daylight_recipe(recipe_name, extension):
          '--name', name, ] + env_args
     )
     assert result.exit_code == 0
-    results_folder = os.path.join(sim_folder, 'results')
+    results_folder = os.path.join(sim_folder, 'results', 'total') \
+        if extension == 'ill' else os.path.join(sim_folder, 'results')
     assert os.path.isfile(os.path.join(results_folder, f'TestRoom_1.{extension}'))
     assert os.path.isfile(os.path.join(results_folder, f'TestRoom_2.{extension}'))
     nukedir(sim_folder, True)


### PR DESCRIPTION
We already store the direct results in the annual-irradiance recipe and I figured that we are eventually going to want the same for annual-daylight when we add support for ASE.